### PR TITLE
Call builer.Build in building SQL

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -600,7 +600,8 @@ func (b *QueryBuilder) indexes() []string {
 	return sortedIndexes
 }
 
-func (b *QueryBuilder) SelectSQL(typ *Struct) (string, []interface{}) {
+func (b *QueryBuilder) SelectSQL(factory *ValueFactory, typ *Struct) (string, []interface{}) {
+	b.Build(factory)
 	where := []string{}
 	args := []interface{}{}
 	for _, condition := range b.conditions.conditions {
@@ -623,7 +624,8 @@ func (b *QueryBuilder) SelectSQL(typ *Struct) (string, []interface{}) {
 	), args
 }
 
-func (b *QueryBuilder) UpdateSQL(updateMap map[string]interface{}) (string, []interface{}) {
+func (b *QueryBuilder) UpdateSQL(factory *ValueFactory, updateMap map[string]interface{}) (string, []interface{}) {
+	b.Build(factory)
 	where := []string{}
 	args := []interface{}{}
 	for _, condition := range b.conditions.conditions {
@@ -640,7 +642,8 @@ func (b *QueryBuilder) UpdateSQL(updateMap map[string]interface{}) (string, []in
 	return fmt.Sprintf("UPDATE `%s` SET %s WHERE %s", b.tableName, strings.Join(setList, ","), strings.Join(where, " AND ")), values
 }
 
-func (b *QueryBuilder) DeleteSQL() (string, []interface{}) {
+func (b *QueryBuilder) DeleteSQL(factory *ValueFactory) (string, []interface{}) {
+	b.Build(factory)
 	where := []string{}
 	args := []interface{}{}
 	for _, condition := range b.conditions.conditions {

--- a/tx_test.go
+++ b/tx_test.go
@@ -477,7 +477,7 @@ func TestTx_FindByQueryBuilderContext(t *testing.T) {
 		tx, err := cache.Begin(conn)
 		NoError(t, err)
 		defer func() { NoError(t, tx.RollbackUnlessCommitted()) }()
-		builder := NewQueryBuilder("user_logs").Eq("id", uint64(1)).Gte("content_id", uint64(1)).Lte("content_id", uint64(1))
+		builder := NewQueryBuilder("user_logs").In("id", []uint64{1}).Gte("content_id", uint64(1)).Lte("content_id", uint64(1))
 		var userLogs UserLogs
 		NoError(t, tx.FindByQueryBuilderContext(context.Background(), builder, &userLogs))
 		NoError(t, tx.Commit())


### PR DESCRIPTION
If including `INCondition`, `builder.QueryArgs()` uses `builder.values`  instead of `builder.rawValues`.
But `builder.values` is nil until called `builder.Build()` for the first time.

So always call `builder.Build()` before call `builder.QueryArgs()` .  And also fix test case.