### PR TITLE
Add SLC Deletetion by QueryBuilder

### DIFF
--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -1363,6 +1363,37 @@ func (c *SecondLevelCache) DeleteByQueryBuilder(ctx context.Context, tx *Tx, bui
 	return nil
 }
 
+func (c *SecondLevelCache) DeleteCacheByQueryBuilder(ctx context.Context, tx *Tx, builder *QueryBuilder) error {
+	defer builder.Release()
+	if !builder.AvailableCache() {
+		if !builder.isIgnoreCache {
+			if err := c.deleteCacheFromSQL(ctx, tx, builder); err != nil {
+				return xerrors.Errorf("failed to delete cache by SQL: %w", err)
+			}
+		}
+		return nil
+	}
+
+	queries, err := builder.BuildWithIndex(c.valueFactory, c.indexes, c.typ)
+	if err != nil {
+		return xerrors.Errorf("failed to build query: %w", err)
+	}
+
+	if !c.isUsedPrimaryKeyBuilder(queries) {
+		if err := c.deleteCacheFromSQL(ctx, tx, builder); err != nil {
+			return xerrors.Errorf("failed to delete cache by SQL: %w", err)
+		}
+	} else {
+		for i := 0; i < queries.Len(); i++ {
+			cacheKey := queries.At(i).cacheKey
+			if err := c.deletePrimaryKey(tx, cacheKey); err != nil {
+				return xerrors.Errorf("failed to delete primary key: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
 func (c *SecondLevelCache) builderByValue(value *StructValue, index *Index) *QueryBuilder {
 	builder := NewQueryBuilder(c.typ.tableName)
 	for _, column := range index.Columns {

--- a/second_level_cache_test.go
+++ b/second_level_cache_test.go
@@ -1348,6 +1348,62 @@ func testDeleteByQueryBuilder(t *testing.T, typ CacheServerType) {
 
 }
 
+func TestDeleteCacheByQueryBuilder(t *testing.T) {
+	for cacheServerType := range []CacheServerType{CacheServerTypeMemcached, CacheServerTypeRedis} {
+		testDeleteCascheByQueryBuilder(t, CacheServerType(cacheServerType))
+	}
+}
+
+func testDeleteCascheByQueryBuilder(t *testing.T, typ CacheServerType) {
+	NoError(t, initCache(conn, typ))
+	slc := NewSecondLevelCache(userLoginType(), cache.cacheServer, TableOption{})
+	NoError(t, slc.WarmUp(conn))
+	t.Run("cache is available", func(t *testing.T) {
+		NoError(t, initUserLoginTable(conn))
+		builder := NewQueryBuilder("user_logins").
+			In("user_id", []uint64{1, 2, 3, 4, 5}).
+			Eq("user_session_id", uint64(1))
+		txConn, err := conn.Begin()
+		NoError(t, err)
+		tx, err := cache.Begin(txConn)
+		NoError(t, err)
+		NoError(t, slc.DeleteCacheByQueryBuilder(context.Background(), tx, builder))
+		NoError(t, tx.Commit())
+	})
+
+	t.Run("not available cache", func(t *testing.T) {
+		NoError(t, initUserLoginTable(conn))
+		builder := NewQueryBuilder("user_logins").
+			Gte("user_session_id", uint64(1)).
+			Lte("user_session_id", uint64(3))
+		txConn, err := conn.Begin()
+		NoError(t, err)
+		tx, err := cache.Begin(txConn)
+		NoError(t, err)
+		NoError(t, slc.DeleteCacheByQueryBuilder(context.Background(), tx, builder))
+		NoError(t, tx.Commit())
+	})
+
+	t.Run("delete by primary keys", func(t *testing.T) {
+		NoError(t, initUserLoginTable(conn))
+		builder := NewQueryBuilder("user_logins").
+			In("id", []uint64{1, 2, 3, 4, 5})
+		txConn, err := conn.Begin()
+		NoError(t, err)
+		tx, err := cache.Begin(txConn)
+		NoError(t, err)
+		NoError(t, slc.DeleteCacheByQueryBuilder(context.Background(), tx, builder))
+
+		var userLogins UserLogins
+		NoError(t, slc.FindByQueryBuilder(context.Background(), tx, builder, &userLogins))
+		if len(userLogins) != 0 {
+			t.Fatal("fail to delete")
+		}
+		NoError(t, tx.Commit())
+	})
+
+}
+
 func TestRawQuery(t *testing.T) {
 	for cacheServerType := range []CacheServerType{CacheServerTypeMemcached, CacheServerTypeRedis} {
 		testRawQuery(t, CacheServerType(cacheServerType))


### PR DESCRIPTION
It's related #43.
For example, when there is a mismatch between RDB and Cache.